### PR TITLE
feat(transform): add tree layout algorithms

### DIFF
--- a/demos/tree-layout-compact-box.html
+++ b/demos/tree-layout-compact-box.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tree</title>
+  <link rel="stylesheet" href="./assets/common.css">
+</head>
+<body>
+<div id="canvas"></div>
+<script src="./assets/jquery-3.2.1.min.js"></script>
+<script src="./assets/g2.js"></script>
+<script src="../build/data-set.js"></script>
+<script>
+  $.getJSON('../test/fixtures/flare.json', data => {
+    const dv = new DataSet.View().source(data, {
+      type: 'hierarchy',
+      pureData: true
+    });
+    dv.transform({
+      type: 'hierarchy.compact-box', // this layout algorithm needs to use pure data
+      direction: 'TB',
+      getHGap() {
+        return 10;
+      },
+      getVGap() {
+        return 10;
+      },
+      getHeight() {
+        return 18;
+      },
+      getWidth(d) {
+        return 18 * d.name.length;
+      }
+    });
+
+    const chart = new G2.Chart({
+      container: 'canvas',
+      forceFit: true,
+      height: window.innerHeight,
+      padding: [ 60, 0, 20, 20 ]
+    });
+    chart.coord().transpose();
+    chart.axis(false);
+    chart.legend(false);
+    // chart.coord('polar');
+
+    const edgeView = chart.view();
+    edgeView.source(dv.getAllLinks().map(link => ({
+      x: [ link.source.x, link.target.x ],
+      y: [ link.source.y, link.target.y ],
+      source: link.source.id,
+      target: link.target.id
+    })));
+    edgeView.edge()
+      .position('x*y')
+      .shape('smooth') // vhv
+      .color('grey')
+      .opacity(0.5)
+      .tooltip('source*target');
+
+    const nodeView = chart.view();
+    nodeView.source(dv.getAllNodes().map(node => ({
+      hasChildren: !!(node.children && node.children.length),
+      name: node.data.name,
+      value: node.value,
+      depth: node.depth,
+      x: node.x,
+      y: node.y
+    })));
+    nodeView.point()
+      .position('x*y')
+      .color('hasChildren')
+      .label('name', {
+        offset: 0,
+        textStyle: (text, item) => {
+          const textAlign = item.point.hasChildren ? 'right' : 'left';
+          return {
+            fill: 'grey',
+            fontSize: 9,
+            textAlign
+          };
+        }
+      });
+
+    chart.render();
+  });
+</script>
+</body>
+</html>

--- a/demos/tree-layout-dendrogram.html
+++ b/demos/tree-layout-dendrogram.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tree</title>
+  <link rel="stylesheet" href="./assets/common.css">
+</head>
+<body>
+<div id="canvas"></div>
+<script src="./assets/jquery-3.2.1.min.js"></script>
+<script src="./assets/g2.js"></script>
+<script src="../build/data-set.js"></script>
+<script>
+  $.getJSON('../test/fixtures/flare.json', data => {
+    const dv = new DataSet.View().source(data, {
+      type: 'hierarchy',
+      pureData: true
+    });
+    dv.transform({
+      type: 'hierarchy.dendrogram', // this layout algorithm needs to use pure data
+      direction: 'TB'
+    });
+
+    const chart = new G2.Chart({
+      container: 'canvas',
+      forceFit: true,
+      height: window.innerHeight,
+      padding: [ 60, 0, 20, 20 ]
+    });
+    chart.coord().transpose();
+    chart.axis(false);
+    chart.legend(false);
+    // chart.coord('polar');
+
+    const edgeView = chart.view();
+    edgeView.source(dv.getAllLinks().map(link => ({
+      x: [ link.source.x, link.target.x ],
+      y: [ link.source.y, link.target.y ],
+      source: link.source.id,
+      target: link.target.id
+    })));
+    edgeView.edge()
+      .position('x*y')
+      .shape('vhv') // vhv
+      .color('grey')
+      .opacity(0.5)
+      .tooltip('source*target');
+
+    const nodeView = chart.view();
+    nodeView.source(dv.getAllNodes().map(node => ({
+      hasChildren: !!(node.children && node.children.length),
+      name: node.data.name,
+      value: node.value,
+      depth: node.depth,
+      x: node.x,
+      y: node.y
+    })));
+    nodeView.point()
+      .position('x*y')
+      .color('hasChildren')
+      .label('name', {
+        offset: 0,
+        textStyle: (text, item) => {
+          const textAlign = item.point.hasChildren ? 'right' : 'left';
+          return {
+            fill: 'grey',
+            fontSize: 9,
+            textAlign
+          };
+        }
+      });
+
+    chart.render();
+  });
+</script>
+</body>
+</html>

--- a/demos/tree-layout-indented.html
+++ b/demos/tree-layout-indented.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tree</title>
+  <link rel="stylesheet" href="./assets/common.css">
+</head>
+<body>
+<div id="canvas"></div>
+<script src="./assets/jquery-3.2.1.min.js"></script>
+<script src="./assets/g2.js"></script>
+<script src="../build/data-set.js"></script>
+<script>
+  $.getJSON('../test/fixtures/flare.json', data => {
+    const dv = new DataSet.View().source(data, {
+      type: 'hierarchy',
+      pureData: true
+    });
+    dv.transform({
+      type: 'hierarchy.indented', // this layout algorithm needs to use pure data
+      direction: 'H'
+    });
+
+    const chart = new G2.Chart({
+      container: 'canvas',
+      forceFit: true,
+      height: window.innerHeight,
+      padding: [ 60, 0, 20, 20 ]
+    });
+    chart.coord().reflect('y');
+    chart.axis(false);
+    chart.legend(false);
+    // chart.coord('polar');
+
+    const edgeView = chart.view();
+    edgeView.source(dv.getAllLinks().map(link => ({
+      x: [ link.source.x, link.target.x ],
+      y: [ link.source.y, link.target.y ],
+      source: link.source.id,
+      target: link.target.id
+    })));
+    edgeView.edge()
+      .position('x*y')
+      .shape('vhv') // vhv
+      .color('grey')
+      .opacity(0.5)
+      .tooltip('source*target');
+
+    const nodeView = chart.view();
+    nodeView.source(dv.getAllNodes().map(node => ({
+      hasChildren: !!(node.children && node.children.length),
+      name: node.data.name,
+      value: node.value,
+      depth: node.depth,
+      side: node.side || 'root',
+      x: node.x,
+      y: node.y
+    })));
+    nodeView.point()
+      .position('x*y')
+      .color('hasChildren')
+      .label('name', {
+        offset: 0,
+        textStyle: (text, item) => {
+          let textAlign;
+          if (item.point.side === 'left') {
+            textAlign = item.point.hasChildren ? 'left' : 'right';
+          } else {
+            textAlign = item.point.hasChildren ? 'right' : 'left';
+          }
+          return {
+            fill: 'grey',
+            fontSize: 9,
+            textAlign
+          };
+        }
+      });
+
+    chart.render();
+  });
+</script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ require('./src/transform/diagram/sankey');
 require('./src/transform/diagram/voronoi');
 // hierarchy
 require('./src/transform/hierarchy/cluster');
+require('./src/transform/hierarchy/compact-box');
+require('./src/transform/hierarchy/dendrogram');
+require('./src/transform/hierarchy/indented');
 require('./src/transform/hierarchy/pack');
 require('./src/transform/hierarchy/partition');
 require('./src/transform/hierarchy/tree');

--- a/src/connector/hierarchy.js
+++ b/src/connector/hierarchy.js
@@ -23,7 +23,11 @@ function connector(data, options, dataView) {
     throw new TypeError('Invalid children: must be a function!');
   }
 
-  dataView.rows = dataView.root = hierarchy(data, children);
+  if (!options.pureData) {
+    dataView.rows = dataView.root = hierarchy(data, children);
+  } else {
+    dataView.rows = dataView.root = data;
+  }
   return data;
 }
 

--- a/src/transform/hierarchy/compact-box.js
+++ b/src/transform/hierarchy/compact-box.js
@@ -1,0 +1,38 @@
+const TreeLayout = require('./layout/base');
+const nonLayeredTidyTree = require('./layout/non-layered-tidy');
+const doTreeLayout = require('./layout/do-layout');
+const assign = require('lodash/assign');
+// const isArray = require('lodash/isArray');
+const {
+  HIERARCHY,
+  registerTransform
+} = require('../../data-set');
+
+class CompactBoxTreeLayout extends TreeLayout {
+  execute() {
+    const me = this;
+    const root = doTreeLayout(me.rootNode, me.options, nonLayeredTidyTree);
+    root.translate(-(root.x + root.width / 2 + root.hgap), -(root.y + root.height / 2 + root.vgap));
+    return root;
+  }
+}
+
+const DEFAULT_OPTIONS = {
+};
+
+function transform(dataView, options) {
+  const root = dataView.root;
+  options = assign({}, DEFAULT_OPTIONS, options);
+
+  if (dataView.dataType !== HIERARCHY) {
+    throw new TypeError('Invalid DataView: This transform is for Hierarchy data only!');
+  }
+
+  const rootNode = new CompactBoxTreeLayout(root, options).execute();
+  dataView.root = rootNode;
+}
+
+registerTransform('hierarchy.compact-box', transform);
+registerTransform('compact-box-tree', transform);
+registerTransform('non-layered-tidy-tree', transform);
+registerTransform('mindmap-logical', transform);

--- a/src/transform/hierarchy/dendrogram.js
+++ b/src/transform/hierarchy/dendrogram.js
@@ -1,0 +1,36 @@
+const TreeLayout = require('./layout/base');
+const dendrogram = require('./layout/dendrogram');
+const doTreeLayout = require('./layout/do-layout');
+const assign = require('lodash/assign');
+// const isArray = require('lodash/isArray');
+const {
+  HIERARCHY,
+  registerTransform
+} = require('../../data-set');
+
+class DendrogramLayout extends TreeLayout {
+  execute() {
+    const me = this;
+    me.rootNode.width = 0;
+    const root = doTreeLayout(me.rootNode, me.options, dendrogram);
+    return root;
+  }
+}
+
+const DEFAULT_OPTIONS = {
+};
+
+function transform(dataView, options) {
+  const root = dataView.root;
+  options = assign({}, DEFAULT_OPTIONS, options);
+
+  if (dataView.dataType !== HIERARCHY) {
+    throw new TypeError('Invalid DataView: This transform is for Hierarchy data only!');
+  }
+
+  const rootNode = new DendrogramLayout(root, options).execute();
+  dataView.root = rootNode;
+}
+
+registerTransform('hierarchy.dendrogram', transform);
+registerTransform('dendrogram', transform);

--- a/src/transform/hierarchy/indented.js
+++ b/src/transform/hierarchy/indented.js
@@ -1,0 +1,64 @@
+const TreeLayout = require('./layout/base');
+const indentedTree = require('./layout/indented');
+const assign = require('lodash/assign');
+const separateTree = require('./layout/separate-root');
+// const isArray = require('lodash/isArray');
+const {
+  HIERARCHY,
+  registerTransform
+} = require('../../data-set');
+
+const VALID_DIRECTIONS = [
+  'LR', // left to right
+  'RL', // right to left
+  'H' // horizontal
+];
+const DEFAULT_DIRECTION = VALID_DIRECTIONS[0];
+
+class IndentedLayout extends TreeLayout {
+  execute() {
+    const me = this;
+    const options = me.options;
+    const root = me.rootNode;
+    options.isHorizontal = true;
+    const indent = options.indent;
+    const direction = options.direction || DEFAULT_DIRECTION;
+    if (direction && VALID_DIRECTIONS.indexOf(direction) === -1) {
+      throw new TypeError(`Invalid direction: ${direction}`);
+    }
+    if (direction === VALID_DIRECTIONS[0]) { // LR
+      indentedTree(root, indent);
+    } else if (direction === VALID_DIRECTIONS[1]) { // RL
+      indentedTree(root, indent);
+      root.right2left();
+    } else if (direction === VALID_DIRECTIONS[2]) { // H
+      // separate into left and right trees
+      const { left, right } = separateTree(root, options);
+      indentedTree(left, indent);
+      left.right2left();
+      indentedTree(right, indent);
+      const bbox = left.getBoundingBox();
+      right.translate(bbox.width, 0);
+      root.x = right.x - root.width / 2;
+    }
+    return root;
+  }
+}
+
+const DEFAULT_OPTIONS = {
+};
+
+function transform(dataView, options) {
+  const root = dataView.root;
+  options = assign({}, DEFAULT_OPTIONS, options);
+
+  if (dataView.dataType !== HIERARCHY) {
+    throw new TypeError('Invalid DataView: This transform is for Hierarchy data only!');
+  }
+
+  const rootNode = new IndentedLayout(root, options).execute();
+  dataView.root = rootNode;
+}
+
+registerTransform('hierarchy.indented', transform);
+registerTransform('indented-tree', transform);

--- a/src/transform/hierarchy/layout/base.js
+++ b/src/transform/hierarchy/layout/base.js
@@ -1,0 +1,16 @@
+
+const Node = require('./node');
+
+class Layout {
+  constructor(root, options = {}) {
+    const me = this;
+    me.options = options;
+    me.rootNode = new Node(root, options);
+  }
+
+  execute() {
+    throw new Error('please override this method');
+  }
+}
+
+module.exports = Layout;

--- a/src/transform/hierarchy/layout/dendrogram.js
+++ b/src/transform/hierarchy/layout/dendrogram.js
@@ -1,0 +1,107 @@
+// wrap tree node
+// TODO considering size
+class WrappedTree {
+  constructor(height, children = []) {
+    const me = this;
+    me.x = me.y = 0;
+    me.leftChild = me.rightChild = null;
+    me.height = height || 0;
+    me.children = children;
+  }
+}
+
+const DEFAULT_OPTIONS = {
+  isHorizontal: true,
+  nodeSep: 20,
+  nodeSize: 20,
+  rankSep: 200,
+  subTreeSep: 10
+};
+
+function convertBack(converted/* WrappedTree */, root/* TreeNode */, isHorizontal) {
+  if (isHorizontal) {
+    root.x = converted.x;
+    root.y = converted.y;
+  } else {
+    root.x = converted.y;
+    root.y = converted.x;
+  }
+  converted.children.forEach((child, i) => {
+    convertBack(child, root.children[i], isHorizontal);
+  });
+}
+
+module.exports = (root, options = {}) => {
+  options = Object.assign({}, DEFAULT_OPTIONS, options);
+
+  let maxDepth = 0;
+  function wrappedTreeFromNode(n) {
+    if (!n) return null;
+    n.width = 0;
+    if (n.depth && n.depth > maxDepth) {
+      maxDepth = n.depth; // get the max depth
+    }
+    const children = n.children;
+    const childrenCount = children.length;
+    const t = new WrappedTree(n.height, []);
+    children.forEach((child, i) => {
+      const childWT = wrappedTreeFromNode(child);
+      t.children.push(childWT);
+      if (i === 0) {
+        // t.leftChild = childWT.leftChild ? childWT.leftChild : childWT
+        t.leftChild = childWT;
+      }
+      if (i === (childrenCount - 1)) {
+        // t.rightChild = childWT.rightChild ? childWT.rightChild : childWT
+        t.rightChild = childWT;
+      }
+    });
+    t.originNode = n;
+    t.isLeaf = n.isLeaf();
+    return t;
+  }
+
+  function getDrawingDepth(t) {
+    if (t.isLeaf || t.children.length === 0) {
+      t.drawingDepth = maxDepth;
+    } else {
+      const depths = t.children.map(child => {
+        return getDrawingDepth(child);
+      });
+      const minChildDepth = Math.min.apply(null, depths);
+      t.drawingDepth = minChildDepth - 1;
+    }
+    return t.drawingDepth;
+  }
+
+  let prevLeaf;
+
+  function position(t) {
+    t.x = t.drawingDepth * options.rankSep;
+    if (t.isLeaf) {
+      t.y = 0;
+      if (prevLeaf) {
+        t.y = prevLeaf.y + prevLeaf.height + options.nodeSep;
+        if (t.originNode.parent !== prevLeaf.originNode.parent) {
+          t.y += options.subTreeSep;
+        }
+      }
+      prevLeaf = t;
+    } else {
+      t.children.forEach(child => {
+        position(child);
+      });
+      t.y = (t.leftChild.y + t.rightChild.y) / 2;
+    }
+  }
+
+  // wrap node
+  const wt = wrappedTreeFromNode(root);
+  // get depth for drawing
+  getDrawingDepth(wt);
+  // get position
+  position(wt);
+  // get x, y
+  convertBack(wt, root, options.isHorizontal);
+  return root;
+};

--- a/src/transform/hierarchy/layout/do-layout.js
+++ b/src/transform/hierarchy/layout/do-layout.js
@@ -1,0 +1,87 @@
+
+const separateTree = require('./separate-root');
+const VALID_DIRECTIONS = [
+  'LR', // left to right
+  'RL', // right to left
+  'TB', // top to bottom
+  'BT', // bottom to top
+  'H', // horizontal
+  'V' // vertical
+];
+const HORIZONTAL_DIRECTIONS = [
+  'LR',
+  'RL',
+  'H'
+];
+const isHorizontal = direction => HORIZONTAL_DIRECTIONS.indexOf(direction) > -1;
+const DEFAULT_DIRECTION = VALID_DIRECTIONS[0];
+
+module.exports = (root, options, layoutAlgrithm) => {
+  const direction = options.direction || DEFAULT_DIRECTION;
+  options.isHorizontal = isHorizontal(direction);
+  if (direction && VALID_DIRECTIONS.indexOf(direction) === -1) {
+    throw new TypeError(`Invalid direction: ${direction}`);
+  }
+
+  if (direction === VALID_DIRECTIONS[0]) {
+    // LR
+    layoutAlgrithm(root, options);
+    // setAnchors(root, 'L', 'R', options);
+  } else if (direction === VALID_DIRECTIONS[1]) {
+    // RL
+    layoutAlgrithm(root, options);
+    root.right2left();
+    // anchors
+    // setAnchors(root, 'R', 'L', options);
+  } else if (direction === VALID_DIRECTIONS[2]) {
+    // TB
+    layoutAlgrithm(root, options);
+    // setAnchors(root, 'T', 'B', options);
+  } else if (direction === VALID_DIRECTIONS[3]) {
+    // BT
+    layoutAlgrithm(root, options);
+    root.bottom2top();
+    // setAnchors(root, 'B', 'T', options);
+  } else if (direction === VALID_DIRECTIONS[4] || direction === VALID_DIRECTIONS[5]) {
+    // H or V
+    // separate into left and right trees
+    const { left, right } = separateTree(root, options);
+    // do layout for left and right trees
+    layoutAlgrithm(left, options);
+    layoutAlgrithm(right, options);
+    // if (options.isHorizontal) {
+    //   setAnchors(left, 'R', 'L', options);
+    //   setAnchors(right, 'L', 'R', options);
+    // } else {
+    //   setAnchors(left, 'B', 'T', options);
+    //   setAnchors(right, 'T', 'B', options);
+    // }
+    options.isHorizontal ? (left.right2left()) : (left.bottom2top());
+    // combine left and right trees
+    right.translate(left.x - right.x, left.y - right.y);
+    // translate root
+    root.x = left.x;
+    root.y = right.y;
+    // setAnchors(root, 'C', 'C', options, true);
+    const bb = root.getBoundingBox();
+    if (options.isHorizontal) {
+      if (bb.top < 0) {
+        root.translate(0, -bb.top);
+      }
+    } else {
+      if (bb.left < 0) {
+        root.translate(-bb.left, 0);
+      }
+    }
+  }
+  root.translate(-(root.x + root.width / 2 + root.hgap), -(root.y + root.height / 2 + root.vgap));
+  root.eachNode(node => {
+    const data = node.data;
+    data.x = node.x + node.width / 2 + node.hgap;
+    data.y = node.y + node.height / 2 + node.vgap;
+    data.align = node.align;
+    // data.inAnchor = node.inAnchor ? [ node.inAnchor.x, node.inAnchor.y ] : null;
+    // data.outAnchor = node.outAnchor ? [ node.outAnchor.x, node.outAnchor.y ] : null;
+  });
+  return root;
+};

--- a/src/transform/hierarchy/layout/indented.js
+++ b/src/transform/hierarchy/layout/indented.js
@@ -1,0 +1,13 @@
+
+const DEFAULT_INDENT = 20;
+function positionNode(node, previousNode, dx) {
+  node.x += dx * node.depth;
+  node.y = previousNode ? previousNode.y + previousNode.height : 0;
+}
+module.exports = (root, indent = DEFAULT_INDENT) => {
+  let previousNode = null;
+  root.eachNode(node => {
+    positionNode(node, previousNode, indent);
+    previousNode = node;
+  });
+};

--- a/src/transform/hierarchy/layout/node.js
+++ b/src/transform/hierarchy/layout/node.js
@@ -1,0 +1,225 @@
+
+const PEM = 18;
+const DEFAULT_HEIGHT = PEM * 2;
+const DEFAULT_GAP = PEM;
+
+const DEFAULT_OPTIONS = {
+  getId(d) {
+    return d.id || d.name;
+  },
+  getHGap(d) {
+    return d.hgap || DEFAULT_GAP;
+  },
+  getVGap(d) {
+    return d.vgap || DEFAULT_GAP;
+  },
+  getChildren(d) {
+    return d.children;
+  },
+  getHeight(d) {
+    return d.height || DEFAULT_HEIGHT;
+  },
+  getWidth(d) {
+    const name = d.name || ' ';
+    return d.width || (name.split('').length * PEM); // FIXME DO NOT get width like this
+  }
+};
+
+class Node {
+  constructor(data, options = {}, isolated) {
+    const me = this;
+    me.vgap = me.hgap = 0;
+    if (data instanceof Node) return data;
+    me.data = data;
+    /*
+     * Gaps: filling space between nodes
+     * (x, y) ----------------------
+     * |            hgap            |
+     * |    --------------------    h
+     * | v |                    |   e
+     * | g |                    |   i
+     * | a |                    |   g
+     * | p |                    |   h
+     * |   ---------------------    t
+     * |                            |
+     *  -----------width------------
+     */
+    const hgap = (options.getHGap || DEFAULT_OPTIONS.getHGap)(data);
+    const vgap = (options.getVGap || DEFAULT_OPTIONS.getVGap)(data);
+    /*
+     * BBox: start point, width, height, etc.
+     * (x, y) ---width--->| (x+width, y)
+     *   |                |
+     *  height            |
+     *   |                |
+     * (x, y+height)----->| (x+width, y+height)
+     */
+    me.width = (options.getWidth || DEFAULT_OPTIONS.getWidth)(data);
+    me.height = (options.getHeight || DEFAULT_OPTIONS.getHeight)(data);
+    me.id = (options.getId || DEFAULT_OPTIONS.getId)(data);
+    me.x = me.y = 0;
+    /*
+     * Anchors: points that edges linked to
+     * (0, 0) --------> (0, 1)
+     *   |                |
+     *   |   (0.5, 0.5)   |
+     *   |                |
+     * (0, 1) --------> (1, 1)
+     */
+    me.inAnchor = {
+      x: 0,
+      y: 0.5
+    };
+    me.outAnchor = {
+      x: 1,
+      y: 0.5
+    };
+    me.depth = 0;
+    if (!isolated && !data.isCollapsed) {
+      const nodes = [ me ];
+      let node = nodes.pop();
+      while (node) {
+        if (!node.data.isCollapsed) {
+          const children = (options.getChildren || DEFAULT_OPTIONS.getChildren)(node.data);
+          const length = children ? children.length : 0;
+          node.children = [];
+          if (children && length) {
+            for (let i = 0; i < length; i++) {
+              const child = new Node(children[i], options);
+              node.children.push(child);
+              nodes.push(child);
+              child.parent = node;
+              child.depth = node.depth + 1;
+            }
+          }
+        }
+        node = nodes.pop();
+      }
+    }
+    if (!me.children) {
+      me.children = [];
+    }
+    me.addGap(hgap, vgap);
+  }
+
+  isRoot() {
+    return (this.depth === 0);
+  }
+
+  isLeaf() {
+    return (this.children.length === 0);
+  }
+
+  addGap(hgap, vgap) {
+    const me = this;
+    me.hgap += hgap;
+    me.vgap += vgap;
+    me.width += 2 * hgap;
+    me.height += 2 * vgap;
+  }
+
+  eachNode(callback) { // Depth First traverse
+    const me = this;
+    let nodes = [ me ];
+    let current = nodes.pop();
+    while (current) {
+      callback(current);
+      nodes = nodes.concat(current.children);
+      current = nodes.pop();
+    }
+  }
+
+  DFTraverse(callback) { // Depth First traverse
+    this.eachNode(callback);
+  }
+
+  BFTraverse(callback) { // Breadth First traverse
+    const me = this;
+    let nodes = [ me ];
+    let current = nodes.shift();
+    while (current) {
+      callback(current);
+      nodes = nodes.concat(current.children);
+      current = nodes.shift();
+    }
+  }
+
+  getBoundingBox() {
+    const bb = {
+      left: Number.MAX_VALUE,
+      top: Number.MAX_VALUE,
+      width: 0,
+      height: 0
+    };
+    this.eachNode(node => {
+      bb.left = Math.min(bb.left, node.x);
+      bb.top = Math.min(bb.top, node.y);
+      bb.width = Math.max(bb.width, node.x + node.width);
+      bb.height = Math.max(bb.height, node.y + node.height);
+    });
+    return bb;
+  }
+
+  // translate
+
+  translate(tx = 0, ty = 0) {
+    this.eachNode(node => {
+      node.x += tx;
+      node.y += ty;
+    });
+  }
+
+  right2left() {
+    const me = this;
+    const bb = me.getBoundingBox();
+    me.eachNode(node => {
+      node.x = node.x - (node.x - bb.left) * 2 - node.width;
+      // node.x = - node.x;
+    });
+    me.translate(bb.width, 0);
+  }
+
+  bottom2top() {
+    const me = this;
+    const bb = me.getBoundingBox();
+    me.eachNode(node => {
+      node.y = node.y - (node.y - bb.top) * 2 - node.height;
+      // node.y = - node.y;
+    });
+    me.translate(0, bb.height);
+  }
+
+  getCenterX() {
+    const me = this;
+    return me.x + me.width / 2;
+  }
+
+  getCenterY() {
+    const me = this;
+    return me.y + me.height / 2;
+  }
+
+  getActualWidth() {
+    const me = this;
+    return me.width - me.hgap * 2;
+  }
+
+  getActualHeight() {
+    const me = this;
+    return me.height - me.vgap * 2;
+  }
+
+  getAnchorPoint(anchor) {
+    const me = this;
+    const width = me.getActualWidth();
+    const height = me.getActualHeight();
+    return {
+      x: me.x + me.hgap + width * anchor.x,
+      y: me.y + me.vgap + height * anchor.y
+    };
+  }
+}
+
+Node.prototype.each = Node.prototype.eachNode;
+
+module.exports = Node;

--- a/src/transform/hierarchy/layout/non-layered-tidy.js
+++ b/src/transform/hierarchy/layout/non-layered-tidy.js
@@ -1,0 +1,251 @@
+// wrap tree node
+class WrappedTree {
+  constructor(w, h, y, c = []) {
+    const me = this;
+    // size
+    me.w = w || 0;
+    me.h = h || 0;
+
+    // position
+    me.y = y || 0;
+    me.x = 0;
+
+    // children
+    me.c = c || [];
+    me.cs = c.length;
+
+    // modified
+    me.prelim = 0;
+    me.mod = 0;
+    me.shift = 0;
+    me.change = 0;
+
+    // left/right tree
+    me.tl = null;
+    me.tr = null;
+
+    // extreme left/right tree
+    me.el = null;
+    me.er = null;
+
+    // modified left/right tree
+    me.msel = 0;
+    me.mser = 0;
+  }
+}
+WrappedTree.fromNode = (root, isHorizontal) => {
+  if (!root) return null;
+  const children = [];
+  root.children.forEach(child => {
+    children.push(WrappedTree.fromNode(child, isHorizontal));
+  });
+  if (isHorizontal) return new WrappedTree(root.height, root.width, root.x, children);
+  return new WrappedTree(root.width, root.height, root.y, children);
+};
+
+// node utils
+function moveRight(node, move, isHorizontal) {
+  if (isHorizontal) {
+    node.y += move;
+  } else {
+    node.x += move;
+  }
+  node.children.forEach(child => {
+    moveRight(child, move, isHorizontal);
+  });
+}
+
+function getMin(node, isHorizontal) {
+  let res = isHorizontal ? node.y : node.x;
+  node.children.forEach(child => {
+    res = Math.min(getMin(child, isHorizontal), res);
+  });
+  return res;
+}
+
+function normalize(node, isHorizontal) {
+  const min = getMin(node, isHorizontal);
+  moveRight(node, -min, isHorizontal);
+}
+
+function convertBack(converted/* WrappedTree */, root/* TreeNode */, isHorizontal) {
+  if (isHorizontal) {
+    root.y = converted.x;
+  } else {
+    root.x = converted.x;
+  }
+  converted.c.forEach((child, i) => {
+    convertBack(child, root.children[i], isHorizontal);
+  });
+}
+
+function layer(node, isHorizontal, d = 0) {
+  if (isHorizontal) {
+    node.x = d;
+    d += node.width;
+  } else {
+    node.y = d;
+    d += node.height;
+  }
+  node.children.forEach(child => {
+    layer(child, isHorizontal, d);
+  });
+}
+
+module.exports = (root, options = {}) => {
+  const isHorizontal = options.isHorizontal;
+  function firstWalk(t) {
+    if (t.cs === 0) {
+      setExtremes(t);
+      return;
+    }
+    firstWalk(t.c[0]);
+    let ih = updateIYL(bottom(t.c[0].el), 0, null);
+    for (let i = 1; i < t.cs; ++i) {
+      firstWalk(t.c[i]);
+      const min = bottom(t.c[i].er);
+      separate(t, i, ih);
+      ih = updateIYL(min, i, ih);
+    }
+    positionRoot(t);
+    setExtremes(t);
+  }
+
+  function setExtremes(t) {
+    if (t.cs === 0) {
+      t.el = t;
+      t.er = t;
+      t.msel = t.mser = 0;
+    } else {
+      t.el = t.c[0].el;
+      t.msel = t.c[0].msel;
+      t.er = t.c[t.cs - 1].er;
+      t.mser = t.c[t.cs - 1].mser;
+    }
+  }
+
+  function separate(t, i, ih) {
+    let sr = t.c[i - 1];
+    let mssr = sr.mod;
+    let cl = t.c[i];
+    let mscl = cl.mod;
+    while (sr !== null && cl !== null) {
+      if (bottom(sr) > ih.low) ih = ih.nxt;
+      const dist = (mssr + sr.prelim + sr.w) - (mscl + cl.prelim);
+      if (dist > 0) {
+        mscl += dist;
+        moveSubtree(t, i, ih.index, dist);
+      }
+      const sy = bottom(sr);
+      const cy = bottom(cl);
+      if (sy <= cy) {
+        sr = nextRightContour(sr);
+        if (sr !== null) mssr += sr.mod;
+      }
+      if (sy >= cy) {
+        cl = nextLeftContour(cl);
+        if (cl !== null) mscl += cl.mod;
+      }
+    }
+    if (!sr && !!cl) {
+      setLeftThread(t, i, cl, mscl);
+    } else if (!!sr && !cl) {
+      setRightThread(t, i, sr, mssr);
+    }
+  }
+
+  function moveSubtree(t, i, si, dist) {
+    t.c[i].mod += dist;
+    t.c[i].msel += dist;
+    t.c[i].mser += dist;
+    distributeExtra(t, i, si, dist);
+  }
+
+  function nextLeftContour(t) {
+    return t.cs === 0 ? t.tl : t.c[0];
+  }
+
+  function nextRightContour(t) {
+    return t.cs === 0 ? t.tr : t.c[t.cs - 1];
+  }
+
+  function bottom(t) {
+    return t.y + t.h;
+  }
+
+  function setLeftThread(t, i, cl, modsumcl) {
+    const li = t.c[0].el;
+    li.tl = cl;
+    const diff = (modsumcl - cl.mod) - t.c[0].msel;
+    li.mod += diff;
+    li.prelim -= diff;
+    t.c[0].el = t.c[i].el;
+    t.c[0].msel = t.c[i].msel;
+  }
+
+  function setRightThread(t, i, sr, modsumsr) {
+    const ri = t.c[i].er;
+    ri.tr = sr;
+    const diff = (modsumsr - sr.mod) - t.c[i].mser;
+    ri.mod += diff;
+    ri.prelim -= diff;
+    t.c[i].er = t.c[i - 1].er;
+    t.c[i].mser = t.c[i - 1].mser;
+  }
+
+  function positionRoot(t) {
+    t.prelim = (
+      t.c[0].prelim + t.c[0].mod + t.c[t.cs - 1].mod +
+      t.c[t.cs - 1].prelim + t.c[t.cs - 1].w
+    ) / 2 - t.w / 2;
+  }
+
+  function secondWalk(t, modsum) {
+    modsum += t.mod;
+    t.x = t.prelim + modsum;
+    addChildSpacing(t);
+    for (let i = 0; i < t.cs; i++) {
+      secondWalk(t.c[i], modsum);
+    }
+  }
+
+  function distributeExtra(t, i, si, dist) {
+    if (si !== i - 1) {
+      const nr = i - si;
+      t.c[si + 1].shift += dist / nr;
+      t.c[i].shift -= dist / nr;
+      t.c[i].change -= dist - dist / nr;
+    }
+  }
+
+  function addChildSpacing(t) {
+    let d = 0;
+    let modsumdelta = 0;
+    for (let i = 0; i < t.cs; i++) {
+      d += t.c[i].shift;
+      modsumdelta += d + t.c[i].change;
+      t.c[i].mod += modsumdelta;
+    }
+  }
+
+  function updateIYL(low, index, ih) {
+    while (ih !== null && low >= ih.low) {
+      ih = ih.nxt;
+    }
+    return {
+      low,
+      index,
+      nxt: ih
+    };
+  }
+
+  // do layout
+  layer(root, isHorizontal);
+  const wt = WrappedTree.fromNode(root, isHorizontal);
+  firstWalk(wt);
+  secondWalk(wt, 0);
+  convertBack(wt, root, isHorizontal);
+  normalize(root, isHorizontal);
+
+  return root;
+};

--- a/src/transform/hierarchy/layout/separate-root.js
+++ b/src/transform/hierarchy/layout/separate-root.js
@@ -1,0 +1,33 @@
+const Node = require('./node');
+
+module.exports = (root, options) => {
+  // separate into left and right trees
+  const left = new Node(root.data, options, true); // root only
+  const right = new Node(root.data, options, true); // root only
+  // automatically
+  // TODO separate left and right tree by meta data
+  const treeSize = root.children.length;
+  const rightTreeSize = Math.round(treeSize / 2);
+  for (let i = 0; i < treeSize; i++) {
+    const child = root.children[i];
+    if (i < rightTreeSize) {
+      right.children.push(child);
+    } else {
+      left.children.push(child);
+    }
+  }
+  left.eachNode(node => {
+    if (!node.isRoot()) {
+      node.side = 'left';
+    }
+  });
+  right.eachNode(node => {
+    if (!node.isRoot()) {
+      node.side = 'right';
+    }
+  });
+  return {
+    left,
+    right
+  };
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

支持三大类树布局（紧凑盒布局、生态树布局和缩进树布局），涵盖了大部分树图、脑图的布局需求。
