### PR TITLE
fix: disabled amd parser of lodash

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,12 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /lodash/,
+        parser: {
+          amd: false
+        }
+      },
+      {
         test: /\.js$/,
         exclude: /(node_modules|bower_components)/,
         use: {


### PR DESCRIPTION
修改 webpack 构建配置，关闭 lodash 的 amd 模块解析。

lodash 导出 amd 模块时默认会向 root 对象上覆盖变量 "_"，如果不关闭 amd 解析，`npm run build` 打包出的代码关于 amd 模块判断是下面这样的，在一些使用了 underscore 的应用中会导致冲突。
```javascript
// build/data-set.js
if (true) {
    root._ = _;

    define(function() {
      return _;
    });
  }
```