### PR TITLE
fix: Remove Warn

### DIFF
--- a/src/transform/percent.ts
+++ b/src/transform/percent.ts
@@ -39,9 +39,6 @@ function transform(dataView: View, options: Options): void {
   const groups = partition(rows, groupBy);
   forIn(groups, (group) => {
     const totalSum = sum(group.map((row: any) => row[field]));
-    if (totalSum === 0) {
-      console.warn(`Invalid data: total sum of field ${field} is 0!`);
-    }
     const innerGroups = partition(group, [dimension]);
     forIn(innerGroups, (innerGroup) => {
       const innerSum = sum(innerGroup.map((row: any) => row[field]));


### PR DESCRIPTION
不合理的 `totalSum === 0` 判断

 totalSum 是有等于0的情况，这种情况没有判断的意义，在大数据都为0的情况下会导致一堆warn.
```
    if (totalSum === 0) {
      console.warn(`Invalid data: total sum of field ${field} is 0!`);
    }
```
