### PR TITLE
fix: bin.histogram的计算默认改为Sturges formula

### DIFF
--- a/test/unit/transform/bin/histogram-spec.ts
+++ b/test/unit/transform/bin/histogram-spec.ts
@@ -20,14 +20,16 @@ describe('View.transform(): bin.histogram', () => {
     expect(getTransform('bin.histogram')).to.be.a('function');
     expect(getTransform('bin.dot')).to.be.a('function');
   });
-
+  /** 改为Sturges formula 更符合数学的意义*/
   it('default', () => {
     dv.transform({
       type: 'bin.histogram',
       field: 'a',
     });
     const firstRow = dv.rows[0];
-    expect(firstRow.x[1] - firstRow.x[0]).to.equal(100 / 30);
+    const binNumber = Math.ceil(Math.log(data.length) / Math.LN2) + 1;
+    //  binWidth = width / binNumber;
+    expect(firstRow.x[1] - firstRow.x[0]).to.equal(100 / binNumber);
   });
 
   it('bins', () => {


### PR DESCRIPTION
bin.histogram 改为符合数学其中一种Sturges formula 方式

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
